### PR TITLE
Skeleton CMake script for G4VG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,21 @@
+#---------------------------------*-CMake-*----------------------------------#
+# Copyright 2020-2024 UT-Battelle, LLC, and other Celeritas developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#----------------------------------------------------------------------------#
+
+cmake_minimum_required(VERSION 3.14...3.28)
+project(G4VG VERSION 0.1.0 LANGUAGES CXX)
+
+include(FetchContent)
+FetchContent_Declare(
+  celeritas
+  # Current tip of celeritas develop - adjust as needed
+  URL https://github.com/celeritas-project/celeritas/archive/5742b0c924a67bf02ec0ce9fc85719a70f7857e0.zip
+)
+
+# Set/force any Celeritas CMake args here before making it available, e.g.
+set(CELERITAS_USE_MPI OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(celeritas)
+
+# Use any celeritas targets as normal (or CMake modules)


### PR DESCRIPTION
This is rough and ready, but shows the basic `FetchContent` calls needed to pull in/make available Celeritas to to build. It's mostly straightforward, but note the following:

- Uses CMake `3.14...3.28` to support easiest use of FetchContent and avoid DOWNLOAD_TIMESTAMP policy warnings
- It uses the URL/zip strategy to download Celeritas as a GitHub's archive of a specific commit
  - "Easiest" and fastest/smallest, but results in warnings from `cgv_find_version` as these archives do not seemingly include the attributes file.

The `GIT_REPO/TAG` strategy could be used, but only as a full checkout. Using `GIT_SHALLOW` to minimise the size also causes warnings from `cgi_find_version`. Not sure what the best/preferred solution is...