### PR TITLE
Add initial implementation

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,161 @@
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: false
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     79
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Regroup
+# Category 0: main include
+# Category 1: system includes
+# Category 2: celeritas absolute includes
+# Category 5: relative includes
+# Category 7: test includes
+IncludeCategories:
+  - Regex:           '^<[^/.]+>$'
+    Priority:        1
+    SortPriority:    1
+  - Regex:           '^<.+>$'
+    Priority:        1
+    SortPriority:    2
+  - Regex:           '^"celeritas_[a-z_]+\.h"'
+    Priority:        2
+    SortPriority:    3
+  - Regex:           '^"corecel/device_runtime_api\.h"$'
+    Priority:        2
+    SortPriority:    3
+  - Regex:           '^"corecel/'
+    Priority:        2
+    SortPriority:    5
+    CaseSensitive:   true
+  - Regex:           '^"orange/'
+    Priority:        2
+    SortPriority:    6
+    CaseSensitive:   true
+  - Regex:           '^"celeritas/'
+    Priority:        2
+    SortPriority:    7
+    CaseSensitive:   true
+  - Regex:           '^"accel/'
+    Priority:        2
+    SortPriority:    8
+    CaseSensitive:   true
+  - Regex:           '^"[^/]+"'
+    Priority:        5
+    SortPriority:    9
+  - Regex:           '^"detail/"'
+    Priority:        5
+    SortPriority:    10
+  - Regex:           '"(^gtest/|TestBase|\.test\.hh|celeritas_test\.hh)'
+    Priority:        7
+    CaseSensitive:   true
+    SortPriority:    11
+  - Regex:           '.*'
+    Priority:        5
+    SortPriority:    9
+IncludeIsMainRegex: '(\.[^.]+)?$'
+IncludeIsMainSourceRegex: '(\.cu|\.t\.hh)$' # Allow CU/template files as main
+IndentCaseLabels: true
+IndentPPDirectives: AfterHash
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 20
+PenaltyBreakBeforeFirstCallParameter: 5
+PenaltyBreakComment: 10
+PenaltyBreakFirstLessLess: 1
+PenaltyBreakString: 25
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 25
+PenaltyReturnTypeOnItsOwnLine: 10
+PointerAlignment: Left
+QualifierAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+...
+# vim: set ft=yaml ts=2 sw=2 :

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,21 @@
 *.exe
 *.out
 *.app
+
+# Misc
+*.cache
+*.pyc
+*.swp
+*~
+.DS_Store
+.nfs*
+.vscode
+/build*
+/install*
+/spack-build*
+/CMakeUserPresets.json
+Testing
+compile_commands.json
+cmake_install.cmake
+/CMakeCache.txt
+/CMakeFiles

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,13 @@
 cmake_minimum_required(VERSION 3.14...3.28)
 project(G4VG VERSION 0.1.0 LANGUAGES CXX)
 
-include(FetchContent)
-FetchContent_Declare(
-  celeritas
-  # Current tip of celeritas develop - adjust as needed
-  URL https://github.com/celeritas-project/celeritas/archive/5742b0c924a67bf02ec0ce9fc85719a70f7857e0.zip
-)
+#----------------------------------------------------------------------------#
+# Includes and setup
 
-# Set/force any Celeritas CMake args here before making it available, e.g.
-set(CELERITAS_USE_MPI OFF CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(celeritas)
+include(GNUInstallDirs)
 
-# Use any celeritas targets as normal (or CMake modules)
+#----------------------------------------------------------------------------#
+# Add code
+
+add_subdirectory(external)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,4 +16,20 @@ include(GNUInstallDirs)
 # Add code
 
 add_subdirectory(external)
+add_subdirectory(src)
+
+#----------------------------------------------------------------------------#
+# Export CMake for installation downstream
+
+set(G4VG_INSTALL_CMAKECONFIGDIR "${CMAKE_INSTALL_LIBDIR}/cmake/G4VG")
+
+# Install 'G4VGTargets.cmake', included by G4VGConfig.cmake, which
+# references the targets we install.
+install(EXPORT g4vg-targets
+  FILE G4VGTargets.cmake
+  NAMESPACE G4VG::
+  DESTINATION "${G4VG_INSTALL_CMAKECONFIGDIR}"
+  COMPONENT development
+)
+
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,0 +1,29 @@
+#----------------------------------*-CMake-*----------------------------------#
+# Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#-----------------------------------------------------------------------------#
+
+include(FetchContent)
+
+macro(g4vg_set_default name value)
+  if(NOT DEFINED ${name})
+    message(VERBOSE "G4VG: set default ${name}=${value}")
+    set(${name} "${value}")
+  endif()
+endmacro()
+
+# Load Celeritas
+FetchContent_Declare(
+  Celeritas
+  EXCLUDE_FROM_ALL
+  # Current tip of celeritas develop - adjust as needed
+  URL https://github.com/celeritas-project/celeritas/archive/5742b0c924a67bf02ec0ce9fc85719a70f7857e0.zip
+)
+
+# $ git "describe" "--tags" "--match" "v*" 5742b0c924; format as below
+set(Celeritas_GIT_DESCRIBE "0.5.0" "-dev.9" "5742b0c92")
+# Load Celeritas
+FetchContent_MakeAvailable(Celeritas)
+
+#-----------------------------------------------------------------------------#

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -23,6 +23,32 @@ FetchContent_Declare(
 
 # $ git "describe" "--tags" "--match" "v*" 5742b0c924; format as below
 set(Celeritas_GIT_DESCRIBE "0.5.0" "-dev.9" "5742b0c92")
+
+# Minimally build Celeritas
+g4vg_set_default(CELERITAS_BUILD_DEMOS OFF)
+g4vg_set_default(CELERITAS_BUILD_DOCS OFF)
+g4vg_set_default(CELERITAS_BUILD_TESTS OFF)
+
+g4vg_set_default(CELERITAS_USE_CUDA OFF)
+g4vg_set_default(CELERITAS_USE_Geant4 ON)
+g4vg_set_default(CELERITAS_USE_HIP OFF)
+g4vg_set_default(CELERITAS_USE_HepMC3 OFF)
+g4vg_set_default(CELERITAS_USE_JSON OFF)
+g4vg_set_default(CELERITAS_USE_MPI OFF)
+g4vg_set_default(CELERITAS_USE_OpenMP OFF)
+g4vg_set_default(CELERITAS_USE_ROOT OFF)
+g4vg_set_default(CELERITAS_USE_SWIG OFF)
+g4vg_set_default(CELERITAS_USE_VecGeom ON)
+
+# Use VecGeom, mm, and double precision
+g4vg_set_default(CELERITAS_CORE_GEO VecGeom)
+g4vg_set_default(CELERITAS_UNITS CLHEP)
+g4vg_set_default(CELERITAS_REAL_TYPE double)
+
+# Build static libraries for celeritas
+g4vg_set_default(BUILD_SHARED_LIBS OFF)
+g4vg_set_default(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 # Load Celeritas
 FetchContent_MakeAvailable(Celeritas)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,34 @@
+#----------------------------------*-CMake-*----------------------------------#
+# Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+# See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+#-----------------------------------------------------------------------------#
+
+#-----------------------------------------------------------------------------#
+# Add the library
+celeritas_rdc_add_library(g4vg
+  G4VG.cc
+)
+celeritas_target_link_libraries(g4vg
+  PRIVATE Celeritas::geocel
+)
+
+# Alias it for downstream code
+add_library(G4VG::g4vg ALIAS g4vg)
+
+# Install all targets to lib/
+install(TARGETS g4vg
+  EXPORT g4vg-targets
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  COMPONENT runtime
+)
+
+# C++ source headers
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  COMPONENT development
+  FILES_MATCHING REGEX ".*\\.hh?$"
+)
+
+#-----------------------------------------------------------------------------#

--- a/src/G4VG.cc
+++ b/src/G4VG.cc
@@ -1,0 +1,58 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file G4VG.cc
+//---------------------------------------------------------------------------//
+#include "G4VG.hh"
+
+#include <geocel/g4vg/Converter.hh>
+
+namespace g4vg
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Convert a Geant4 geometry to a VecGeom geometry.
+ *
+ * Return the new world volume and a mapping of Geant4 logical volumes to
+ * VecGeom-based volume IDs.
+ */
+Converted convert(G4VPhysicalVolume const* world)
+{
+    return convert(world, {});
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Convert with custom options.
+ */
+Converted convert(G4VPhysicalVolume const* world, Options options)
+{
+    using Converter = ::celeritas::g4vg::Converter;
+
+    // Construct converter
+    Converter convert{[&options] {
+        Converter::Options geocel_opts;
+        geocel_opts.verbose = options.verbose;
+        geocel_opts.compare_volumes = options.compare_volumes;
+        return geocel_opts;
+    }()};
+
+    // Convert
+    auto geocel_result = convert(world);
+
+    // Remap output to remove volume IDs
+    Converted converted;
+    converted.world = geocel_result.world;
+    converted.volumes.reserve(geocel_result.volumes.size());
+    for (auto&& [lv, vid] : geocel_result.volumes)
+    {
+        converted.volumes.insert({lv, vid.unchecked_get()});
+    }
+
+    return converted;
+}
+
+//---------------------------------------------------------------------------//
+}  // namespace g4vg

--- a/src/G4VG.hh
+++ b/src/G4VG.hh
@@ -1,0 +1,69 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file G4VG.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <unordered_map>
+
+//---------------------------------------------------------------------------//
+// FORWARD DECLARATIONS
+//---------------------------------------------------------------------------//
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+
+namespace vecgeom
+{
+inline namespace cxx
+{
+class VPlacedVolume;
+}  // namespace cxx
+}  // namespace vecgeom
+//---------------------------------------------------------------------------//
+
+namespace g4vg
+{
+//---------------------------------------------------------------------------//
+/*!
+ * Construction options to pass to the converter.
+ */
+struct Options
+{
+    //! Print extra messages for debugging
+    bool verbose{false};
+
+    //! Perform conversion checks
+    bool compare_volumes{false};
+
+    //! TODO: allow client to use a different unit system (default: mm = 1)
+    static constexpr double scale = 1;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+ * Result from converting from Geant4 to VecGeom.
+ */
+struct Converted
+{
+    using VGPlacedVolume = vecgeom::VPlacedVolume;
+    using MapLvVolId = std::unordered_map<G4LogicalVolume const*, unsigned int>;
+
+    //! World pointer (host) corresponding to input Geant4 world
+    VGPlacedVolume* world{nullptr};
+
+    //! Map of Geant4 logical volumes to VecGeom LV IDs
+    MapLvVolId volumes;
+};
+
+//---------------------------------------------------------------------------//
+// Convert a Geant4 geometry to a VecGeom geometry.
+Converted convert(G4VPhysicalVolume const* world);
+
+// Convert with custom options
+Converted convert(G4VPhysicalVolume const* world, Options options);
+
+//---------------------------------------------------------------------------//
+}  // namespace g4vg


### PR DESCRIPTION
This configures a minimal build of Celeritas and adds a small wrapper function around the celeritas converter. 

**WIP** as this requires:
-  https://github.com/celeritas-project/celeritas/pull/1095
-  https://github.com/celeritas-project/celeritas/pull/1098 
-  https://github.com/celeritas-project/celeritas/pull/1099

and then we need to update the external hash. I have checked that, as expected, only the celeritas geometry components compile.