### PR TITLE
Update to new celeritas and RDC utilities

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -10,11 +10,12 @@ include(FetchContent)
 FetchContent_Declare(
   Celeritas
   EXCLUDE_FROM_ALL
-  URL https://github.com/celeritas-project/celeritas/archive/052ac4cd74abc0a6805f2a4168b4683bb589bb59.zip
+  URL https://github.com/celeritas-project/celeritas/archive/0f74ea935d72bed23b82fad98402bc68dd606d94.zip
 )
 
-# $ git "describe" "--tags" "--match" "v*" 052ac4cd7; format as below
-set(Celeritas_GIT_DESCRIBE "0.5.0" "-dev.20" "052ac4cd7")
+# $ git "describe" "--tags" "--match" "v*" <hash> ->
+# v0.5.0-dev-27-g0f74ea935
+set(Celeritas_GIT_DESCRIBE "0.5.0" "-dev.27" "0f74ea935")
 
 # Minimally build Celeritas
 g4vg_set_default(CELERITAS_BUILD_DEMOS OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,13 +6,13 @@
 
 #-----------------------------------------------------------------------------#
 # Add the library
-celeritas_rdc_add_library(g4vg SHARED
+cuda_rdc_add_library(g4vg SHARED
   G4VG.cc
 )
-celeritas_target_link_libraries(g4vg
+cuda_rdc_target_link_libraries(g4vg
   PRIVATE Celeritas::geocel
 )
-celeritas_target_include_directories(g4vg
+cuda_rdc_target_include_directories(g4vg
   PUBLIC
     "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>"
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"


### PR DESCRIPTION
This includes celeritas-project/celeritas#1109 (so now G4VG links against 14 Geant4 libraries instead of 30) and celeritas-project/celeritas#1104 (so there are no longer celeritas-scoped cmake functions being called).