### PR TITLE
Force exclude-from-all on FetchContent subdirectory

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -43,12 +43,15 @@ g4vg_set_default(CELERITAS_REAL_TYPE double)
 g4vg_set_default(BUILD_SHARED_LIBS OFF)
 g4vg_set_default(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+# Load Celeritas
 if(CMAKE_VERSION VERSION_LESS 3.28)
   # See https://gitlab.kitware.com/cmake/cmake/-/issues/20167
-  set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL YES)
+  if(NOT celeritas_POPULATED)
+    FetchContent_Populate(Celeritas)
+    add_subdirectory(${celeritas_SOURCE_DIR} ${celeritas_BINARY_DIR} EXCLUDE_FROM_ALL)
+  endif()
+else()
+  FetchContent_MakeAvailable(Celeritas)
 endif()
-
-# Load Celeritas
-FetchContent_MakeAvailable(Celeritas)
 
 #-----------------------------------------------------------------------------#


### PR DESCRIPTION
Versions of CMake prior to 3.28 (3.20 tested) do not appear to respect, or at least propagate, `EXCLUDE_FROM_ALL` to subdirectories added through `FetchContent_MakeAvailable`. This results in install failures due to attempts to install unbuilt targets, suggesting partial propagation and/or a bug in CMake.

Workaround issue by manually populating and adding subproject with explicit `add_subdirectory(... EXCLUDE_FROM_ALL)`.

@sethrj, I didn't push directly just to double check this fix with you!