### PR TITLE
Configure and install CMake config file for clients

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,26 @@ endif()
 
 set(G4VG_INSTALL_CMAKECONFIGDIR "${CMAKE_INSTALL_LIBDIR}/cmake/G4VG")
 
+# Install 'G4VGConfig.cmake'
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${CMAKE_CURRENT_BINARY_DIR}/G4VGConfigVersion.cmake"
+  COMPATIBILITY AnyNewerVersion
+)
+configure_package_config_file(
+  "cmake/G4VGConfig.cmake.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/G4VGConfig.cmake"
+  INSTALL_DESTINATION "${G4VG_INSTALL_CMAKECONFIGDIR}"
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/G4VGConfigVersion.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/G4VGConfig.cmake"
+  DESTINATION "${G4VG_INSTALL_CMAKECONFIGDIR}"
+  COMPONENT development
+)
+
 # Install 'G4VGTargets.cmake', included by G4VGConfig.cmake, which
 # references the targets we install.
 install(EXPORT g4vg-targets

--- a/cmake/G4VGConfig.cmake.in
+++ b/cmake/G4VGConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/G4VGTargets.cmake")
+


### PR DESCRIPTION
G4VG does not currently install a config file for use with CMake's `find_package` command. Downstream clients cannot therefore find nor export G4VG (if imported as a subproject) in their projects.

Configure and install config and version files for G4VG for use by CMake's `find_package` command.