### PR TITLE
Allow use of external Celeritas

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,17 @@ g4vg_set_default(CMAKE_CXX_EXTENSIONS OFF)
 find_package(Geant4 REQUIRED)
 find_package(VecGeom REQUIRED)
 
+# Celeritas *might* be coming from a superproject...
+if(NOT Celeritas_FOUND)
+  find_package(Celeritas QUIET)
+  if(NOT Celeritas_FOUND)
+    add_subdirectory(external)
+  endif()
+endif()
+
 #----------------------------------------------------------------------------#
 # Add code
 
-add_subdirectory(external)
 add_subdirectory(src)
 
 #----------------------------------------------------------------------------#


### PR DESCRIPTION
Supports co-working with an existing install of Celeritas to avoid duplicate symbols or over-compilation. Primary use case is supporting development of common frontend to Celeritas/AdePT for experiment integration testing (the [drbenmorgan/celer-adept](https://github.com/drbenmorgan/celer-adept) PoP).