### PR TITLE
Make linking to Geant4 static/shared targets consistent

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,13 +34,20 @@ install(TARGETS g4vg_impl
 if(Geant4_VERSION VERSION_LESS 10.6)
   set(_g4vg_impl_libs ${Geant4_LIBRARIES})
 else()
+  # Geant4 might be built with static and/or shared libraries, so link
+  # static-static and shared-shared if possible, falling back to shared-static if needed.
+  set(_g4_link_ext )
+  if((NOT Geant4_shared_FOUND) OR (Geant4_static_FOUND AND NOT BUILD_SHARED_LIBS))
+    set(_g4_link_ext "-static")
+  endif()
+
   # Whilst geocel contains the primary Geant4/VecGeom dependency, we must also
   # declare the geometry/gdml deps explicitly so that clients can pick them
   # up correctly through LINK_DEPENDENT_LIBRARIES should the linker require it.
   # See: https://discourse.cmake.org/t/use-cases-for-imported-link-dependent-libraries
   set(_g4vg_impl_libs
-    Geant4::G4geometry
-    $<IF:$<TARGET_EXISTS:Geant4::G4gdml>,Geant4::G4gdml,Geant4::G4persistency>
+    Geant4::G4geometry${_g4_link_ext}
+    $<IF:$<TARGET_EXISTS:Geant4::G4gdml${_g4_link_ext}>,Geant4::G4gdml${_g4_link_ext},Geant4::G4persistency${_g4_link_ext}>
   )
 endif()
 


### PR DESCRIPTION
Geant4 can be installed with both shared and static libraries at the same time. G4VG only links to the default shared targets, and so use of Geant4 installs that only provide static libs will lead to a CMake-time error about missing targets. We would also like to be consistent in linking so that a static(shared) G4VG should link to static(shared) Geant4 libraries if available, falling back to what's available as a last resort.

Check availability of Geant4 shared/static targets against how G4VG will be linked. Link static(shared) G4VG to static(shared) Geant4 where possible, otherwise link to whatever single link type is provided by the Geant4 install. This is _roughly_ the same logic as used in Celeritas'  `celeritas_get_g4libs` function albeit using `...FOUND` variables supplied by `Geant4Config.cmake`.

Fixes: #17 