### PR TITLE
Implement conversion of G4PVReplica to VecGeom PlacedVolumes

### DIFF
--- a/src/g4vg_impl/Converter.cc
+++ b/src/g4vg_impl/Converter.cc
@@ -13,7 +13,9 @@
 #include <G4LogicalVolumeStore.hh>
 #include <G4PVDivision.hh>
 #include <G4PVPlacement.hh>
+#include <G4PVReplica.hh>
 #include <G4ReflectionFactory.hh>
+#include <G4ReplicaNavigation.hh>
 #include <G4VPhysicalVolume.hh>
 #include <VecGeom/management/Logger.h>
 #include <VecGeom/management/ReflFactory.h>
@@ -306,6 +308,18 @@ auto Converter::build_with_daughters(G4LogicalVolume const* mother_g4lv)
 
                 // Add a copy
                 place_daughter(g4pv);
+            }
+        }
+        else if (auto* replica = dynamic_cast<G4PVReplica*>(g4pv))
+        {
+            // TODO: check and error if the replica uses the kRaxis replication
+            G4ReplicaNavigation replica_navigator;
+            for (size_type j = 0, jmax = replica->GetMultiplicity(); j != jmax;
+                 ++j)
+            {
+                replica_navigator.ComputeTransformation(j, replica);
+                replica->SetCopyNo(j);
+                place_daughter(replica);
             }
         }
         else

--- a/test/G4VG.test.cc
+++ b/test/G4VG.test.cc
@@ -489,5 +489,92 @@ TEST_F(CmsEeBackDeeTest, no_refl_factory)
 }
 
 //---------------------------------------------------------------------------//
+class ReplicaTest : public G4VGTestBase
+{
+  protected:
+    std::string basename() const override { return "B5"; }
+
+    static TestResult base_ref();
+};
+
+TestResult ReplicaTest::base_ref()
+{
+    TestResult ref;
+    ref.lv_name = {
+        "magneticLogical",
+        "hodoscope1Logical",
+        "wirePlane1Logical",
+        "chamber1Logical",
+        "firstArmLogical",
+        "hodoscope2Logical",
+        "wirePlane2Logical",
+        "chamber2Logical",
+        "cellLogical",
+        "EMcalorimeterLogical",
+        "HadCalScintiLogical",
+        "HadCalLayerLogical",
+        "HadCalCellLogical",
+        "HadCalColumnLogical",
+        "HadCalorimeterLogical",
+        "secondArmLogical",
+        "worldLogical",
+    };
+    ref.solid_capacity = {
+        6283185307.179586,
+        400000.0,
+        240000.0,
+        2.4e+07,
+        3.6e+10,
+        400000.0,
+        360000.0,
+        3.6e+07,
+        6.75e+06,
+        5.4e+08,
+        900000.0,
+        4.5e+06,
+        9e+07,
+        1.8e+08,
+        1.8e+09,
+        1.12e+11,
+        2.4e+12,
+    };
+    ref.pv_name = {
+        "magneticPhysical",
+    };
+    // 15 direct placements
+    ref.pv_name.insert(ref.pv_name.end(), 15, "hodoscope1Physical");
+    ref.pv_name.push_back("wirePlane1Physical");
+    // 5 direct placements
+    ref.pv_name.insert(ref.pv_name.end(), 5, "chamber1Physical");
+    ref.pv_name.push_back("firstArmPhysical");
+    // 25 direct placements
+    ref.pv_name.insert(ref.pv_name.end(), 25, "hodoscope2Physical");
+    ref.pv_name.push_back("wirePlane2Physical");
+    // 5 direct placements
+    ref.pv_name.insert(ref.pv_name.end(), 5, "chamber2Physical");
+    // 20x4 = 80 parameterized placements of cellLogical
+    ref.pv_name.insert(ref.pv_name.end(), 80, "cellLogical_param");
+    ref.pv_name.push_back("EMcalorimeterPhysical");
+    ref.pv_name.push_back("HadCalScintiPhysical");
+    // 20 replicas of HadCalLayerLogical
+    ref.pv_name.insert(ref.pv_name.end(), 20, "HadCalLayerLogical_PV");
+    // 2 replicas of HadCalCellLogical
+    ref.pv_name.insert(ref.pv_name.end(), 2, "HadCalCellLogical_PV");
+    // 10 replicas of HadCalColumnLogical
+    ref.pv_name.insert(ref.pv_name.end(), 10, "HadCalColumnLogical_PV");
+    ref.pv_name.push_back("HadCalorimeterPhysical");
+    ref.pv_name.push_back("fSecondArmPhys");
+    ref.pv_name.push_back("worldLogical_PV");
+
+    return ref;
+}
+
+TEST_F(ReplicaTest, default_options)
+{
+    auto result = this->run(Options{});
+    result.expect_eq(this->base_ref());
+}
+
+//---------------------------------------------------------------------------//
 }  // namespace test
 }  // namespace g4vg

--- a/test/data/B5.gdml
+++ b/test/data/B5.gdml
@@ -779,7 +779,7 @@
         <position name="HadCalorimeterPhysical0x157178650_pos" unit="mm" x="0" y="0" z="3000"/>
       </physvol>
     </volume>
-    <volume name="worldLogical0x1571743d0">
+    <volume name="worldLogical">
       <materialref ref="G4_AIR0x15716fd60"/>
       <solidref ref="worldBox0x157173ff0"/>
       <physvol name="magneticPhysical0x157174ea0">
@@ -799,7 +799,7 @@
   </structure>
 
   <setup name="Default" version="1.0">
-    <world ref="worldLogical0x1571743d0"/>
+    <world ref="worldLogical"/>
   </setup>
 
 </gdml>

--- a/test/data/B5.gdml
+++ b/test/data/B5.gdml
@@ -1,0 +1,805 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gdml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://cern.ch/service-spi/app/releases/GDML/schema/gdml.xsd">
+
+  <define/>
+
+  <materials>
+    <isotope N="12" Z="6" name="C120x15716fe80">
+      <atom unit="g/mole" value="12"/>
+    </isotope>
+    <isotope N="13" Z="6" name="C130x15716fee0">
+      <atom unit="g/mole" value="13.0034"/>
+    </isotope>
+    <element name="C0x15716ff30">
+      <fraction n="0.9893" ref="C120x15716fe80"/>
+      <fraction n="0.0107" ref="C130x15716fee0"/>
+    </element>
+    <isotope N="14" Z="7" name="N140x157170130">
+      <atom unit="g/mole" value="14.0031"/>
+    </isotope>
+    <isotope N="15" Z="7" name="N150x157170190">
+      <atom unit="g/mole" value="15.0001"/>
+    </isotope>
+    <element name="N0x1571701e0">
+      <fraction n="0.99632" ref="N140x157170130"/>
+      <fraction n="0.00368" ref="N150x157170190"/>
+    </element>
+    <isotope N="16" Z="8" name="O160x157170390">
+      <atom unit="g/mole" value="15.9949"/>
+    </isotope>
+    <isotope N="17" Z="8" name="O170x157170410">
+      <atom unit="g/mole" value="16.9991"/>
+    </isotope>
+    <isotope N="18" Z="8" name="O180x157170450">
+      <atom unit="g/mole" value="17.9992"/>
+    </isotope>
+    <element name="O0x157170490">
+      <fraction n="0.99757" ref="O160x157170390"/>
+      <fraction n="0.00038" ref="O170x157170410"/>
+      <fraction n="0.00205" ref="O180x157170450"/>
+    </element>
+    <isotope N="36" Z="18" name="Ar360x157170690">
+      <atom unit="g/mole" value="35.9675"/>
+    </isotope>
+    <isotope N="38" Z="18" name="Ar380x1571706d0">
+      <atom unit="g/mole" value="37.9627"/>
+    </isotope>
+    <isotope N="40" Z="18" name="Ar400x1571703d0">
+      <atom unit="g/mole" value="39.9624"/>
+    </isotope>
+    <element name="Ar0x1571707b0">
+      <fraction n="0.003365" ref="Ar360x157170690"/>
+      <fraction n="0.000632" ref="Ar380x1571706d0"/>
+      <fraction n="0.996003" ref="Ar400x1571703d0"/>
+    </element>
+    <material name="G4_AIR0x15716fd60" state="gas">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="85.7"/>
+      <D unit="g/cm3" value="0.00120479"/>
+      <fraction n="0.000124000124000124" ref="C0x15716ff30"/>
+      <fraction n="0.755267755267755" ref="N0x1571701e0"/>
+      <fraction n="0.231781231781232" ref="O0x157170490"/>
+      <fraction n="0.0128270128270128" ref="Ar0x1571707b0"/>
+    </material>
+    <isotope N="1" Z="1" name="H10x157171be0">
+      <atom unit="g/mole" value="1.00782503081372"/>
+    </isotope>
+    <isotope N="2" Z="1" name="H20x157171c20">
+      <atom unit="g/mole" value="2.01410199966617"/>
+    </isotope>
+    <element name="H0x157171c60">
+      <fraction n="0.999885" ref="H10x157171be0"/>
+      <fraction n="0.000115" ref="H20x157171c20"/>
+    </element>
+    <material name="G4_PLASTIC_SC_VINYLTOLUENE0x157171a90" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="64.7"/>
+      <D unit="g/cm3" value="1.032"/>
+      <fraction n="0.914708531800025" ref="C0x15716ff30"/>
+      <fraction n="0.0852914681999746" ref="H0x157171c60"/>
+    </material>
+    <material name="G4_Ar0x157170e80" state="gas">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="188"/>
+      <D unit="g/cm3" value="0.00166201"/>
+      <fraction n="1" ref="Ar0x1571707b0"/>
+    </material>
+    <isotope N="133" Z="55" name="Cs1330x1571722c0">
+      <atom unit="g/mole" value="132.905"/>
+    </isotope>
+    <element name="Cs0x157172590">
+      <fraction n="1" ref="Cs1330x1571722c0"/>
+    </element>
+    <isotope N="127" Z="53" name="I1270x1571727b0">
+      <atom unit="g/mole" value="126.904"/>
+    </isotope>
+    <element name="I0x157172800">
+      <fraction n="1" ref="I1270x1571727b0"/>
+    </element>
+    <material name="G4_CESIUM_IODIDE0x157171f90" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="553.1"/>
+      <D unit="g/cm3" value="4.51"/>
+      <fraction n="0.511548868591927" ref="Cs0x157172590"/>
+      <fraction n="0.488451131408073" ref="I0x157172800"/>
+    </material>
+    <isotope N="204" Z="82" name="Pb2040x1571730d0">
+      <atom unit="g/mole" value="203.973"/>
+    </isotope>
+    <isotope N="206" Z="82" name="Pb2060x157172bc0">
+      <atom unit="g/mole" value="205.974"/>
+    </isotope>
+    <isotope N="207" Z="82" name="Pb2070x157172c00">
+      <atom unit="g/mole" value="206.976"/>
+    </isotope>
+    <isotope N="208" Z="82" name="Pb2080x157170710">
+      <atom unit="g/mole" value="207.977"/>
+    </isotope>
+    <element name="Pb0x1571736a0">
+      <fraction n="0.014" ref="Pb2040x1571730d0"/>
+      <fraction n="0.241" ref="Pb2060x157172bc0"/>
+      <fraction n="0.221" ref="Pb2070x157172c00"/>
+      <fraction n="0.524" ref="Pb2080x157170710"/>
+    </element>
+    <material name="G4_Pb0x157173590" state="solid">
+      <T unit="K" value="293.15"/>
+      <MEE unit="eV" value="823"/>
+      <D unit="g/cm3" value="11.35"/>
+      <fraction n="1" ref="Pb0x1571736a0"/>
+    </material>
+  </materials>
+
+  <solids>
+    <tube aunit="deg" deltaphi="360" lunit="mm" name="magneticTubs0x157174c10" rmax="1000" rmin="0" startphi="0" z="2000"/>
+    <box lunit="mm" name="hodoscope1Box0x1571755f0" x="100" y="400" z="10"/>
+    <box lunit="mm" name="wirePlane1Box0x157176540" x="2000" y="600" z="0.2"/>
+    <box lunit="mm" name="chamber1Box0x157176000" x="2000" y="600" z="20"/>
+    <box lunit="mm" name="firstArmBox0x157174fe0" x="3000" y="2000" z="6000"/>
+    <box lunit="mm" name="hodoscope2Box0x1571767e0" x="100" y="400" z="10"/>
+    <box lunit="mm" name="wirePlane2Box0x157177c20" x="3000" y="600" z="0.2"/>
+    <box lunit="mm" name="chamber2Box0x157177760" x="3000" y="600" z="20"/>
+    <box lunit="mm" name="cellBox0x1571781a0" x="150" y="150" z="300"/>
+    <box lunit="mm" name="EMcalorimeterBox0x157177ec0" x="3000" y="600" z="300"/>
+    <box lunit="mm" name="HadCalScintiBox0x157178fe0" x="300" y="300" z="10"/>
+    <box lunit="mm" name="HadCalLayerBox0x157178cf0" x="300" y="300" z="50"/>
+    <box lunit="mm" name="HadCalCellBox0x157178a00" x="300" y="300" z="1000"/>
+    <box lunit="mm" name="HadCalColumnBox0x157178770" x="300" y="600" z="1000"/>
+    <box lunit="mm" name="HadCalorimeterBox0x157178440" x="3000" y="600" z="1000"/>
+    <box lunit="mm" name="secondArmBox0x157175310" x="4000" y="4000" z="7000"/>
+    <box lunit="mm" name="worldBox0x157173ff0" x="20000" y="6000" z="20000"/>
+  </solids>
+
+  <structure>
+    <volume name="magneticLogical0x157174d60">
+      <materialref ref="G4_AIR0x15716fd60"/>
+      <solidref ref="magneticTubs0x157174c10"/>
+    </volume>
+    <volume name="hodoscope1Logical0x1571756b0">
+      <materialref ref="G4_PLASTIC_SC_VINYLTOLUENE0x157171a90"/>
+      <solidref ref="hodoscope1Box0x1571755f0"/>
+    </volume>
+    <volume name="wirePlane1Logical0x1571765b0">
+      <materialref ref="G4_Ar0x157170e80"/>
+      <solidref ref="wirePlane1Box0x157176540"/>
+    </volume>
+    <volume name="chamber1Logical0x157176070">
+      <materialref ref="G4_Ar0x157170e80"/>
+      <solidref ref="chamber1Box0x157176000"/>
+      <physvol name="wirePlane1Physical0x1571766d0">
+        <volumeref ref="wirePlane1Logical0x1571765b0"/>
+      </physvol>
+    </volume>
+    <volume name="firstArmLogical0x1571750c0">
+      <materialref ref="G4_AIR0x15716fd60"/>
+      <solidref ref="firstArmBox0x157174fe0"/>
+      <physvol name="hodoscope1Physical0x1571757a0">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x1571757a0_pos" unit="mm" x="-700" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="1" name="hodoscope1Physical0x157175870">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175870_pos" unit="mm" x="-600" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="2" name="hodoscope1Physical0x1571758f0">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x1571758f0_pos" unit="mm" x="-500" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="3" name="hodoscope1Physical0x1571759a0">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x1571759a0_pos" unit="mm" x="-400" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="4" name="hodoscope1Physical0x157175a10">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175a10_pos" unit="mm" x="-300" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="5" name="hodoscope1Physical0x157175b00">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175b00_pos" unit="mm" x="-200" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="6" name="hodoscope1Physical0x157175b50">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175b50_pos" unit="mm" x="-100" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="7" name="hodoscope1Physical0x157175ba0">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175ba0_pos" unit="mm" x="0" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="8" name="hodoscope1Physical0x157175c10">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175c10_pos" unit="mm" x="100" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="9" name="hodoscope1Physical0x157175d80">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175d80_pos" unit="mm" x="200" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="10" name="hodoscope1Physical0x157175aa0">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175aa0_pos" unit="mm" x="300" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="11" name="hodoscope1Physical0x157175df0">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175df0_pos" unit="mm" x="400" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="12" name="hodoscope1Physical0x157175e60">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175e60_pos" unit="mm" x="500" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="13" name="hodoscope1Physical0x157175ed0">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175ed0_pos" unit="mm" x="600" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="14" name="hodoscope1Physical0x157175f40">
+        <volumeref ref="hodoscope1Logical0x1571756b0"/>
+        <position name="hodoscope1Physical0x157175f40_pos" unit="mm" x="700" y="0" z="-1500"/>
+      </physvol>
+      <physvol name="chamber1Physical0x157176190">
+        <volumeref ref="chamber1Logical0x157176070"/>
+        <position name="chamber1Physical0x157176190_pos" unit="mm" x="0" y="0" z="-1000"/>
+      </physvol>
+      <physvol copynumber="1" name="chamber1Physical0x157176250">
+        <volumeref ref="chamber1Logical0x157176070"/>
+        <position name="chamber1Physical0x157176250_pos" unit="mm" x="0" y="0" z="-500"/>
+      </physvol>
+      <physvol copynumber="2" name="chamber1Physical0x1571763c0">
+        <volumeref ref="chamber1Logical0x157176070"/>
+      </physvol>
+      <physvol copynumber="3" name="chamber1Physical0x157176410">
+        <volumeref ref="chamber1Logical0x157176070"/>
+        <position name="chamber1Physical0x157176410_pos" unit="mm" x="0" y="0" z="500"/>
+      </physvol>
+      <physvol copynumber="4" name="chamber1Physical0x157176460">
+        <volumeref ref="chamber1Logical0x157176070"/>
+        <position name="chamber1Physical0x157176460_pos" unit="mm" x="0" y="0" z="1000"/>
+      </physvol>
+    </volume>
+    <volume name="hodoscope2Logical0x157176870">
+      <materialref ref="G4_PLASTIC_SC_VINYLTOLUENE0x157171a90"/>
+      <solidref ref="hodoscope2Box0x1571767e0"/>
+    </volume>
+    <volume name="wirePlane2Logical0x157177c90">
+      <materialref ref="G4_Ar0x157170e80"/>
+      <solidref ref="wirePlane2Box0x157177c20"/>
+    </volume>
+    <volume name="chamber2Logical0x1571777d0">
+      <materialref ref="G4_Ar0x157170e80"/>
+      <solidref ref="chamber2Box0x157177760"/>
+      <physvol name="wirePlane2Physical0x157177db0">
+        <volumeref ref="wirePlane2Logical0x157177c90"/>
+      </physvol>
+    </volume>
+    <volume name="cellLogical0x157178220">
+      <materialref ref="G4_CESIUM_IODIDE0x157171f90"/>
+      <solidref ref="cellBox0x1571781a0"/>
+    </volume>
+    <volume name="EMcalorimeterLogical0x157177f50">
+      <materialref ref="G4_CESIUM_IODIDE0x157171f90"/>
+      <solidref ref="EMcalorimeterBox0x157177ec0"/>
+      <paramvol ncopies="80">
+        <volumeref ref="cellLogical0x157178220"/>
+        <parameterised_position_size>
+          <parameters number="1">
+            <position name="cellPhysical0x1571783500_pos" unit="mm" x="-1425" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="2">
+            <position name="cellPhysical0x1571783501_pos" unit="mm" x="-1425" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="3">
+            <position name="cellPhysical0x1571783502_pos" unit="mm" x="-1425" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="4">
+            <position name="cellPhysical0x1571783503_pos" unit="mm" x="-1425" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="5">
+            <position name="cellPhysical0x1571783504_pos" unit="mm" x="-1275" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="6">
+            <position name="cellPhysical0x1571783505_pos" unit="mm" x="-1275" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="7">
+            <position name="cellPhysical0x1571783506_pos" unit="mm" x="-1275" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="8">
+            <position name="cellPhysical0x1571783507_pos" unit="mm" x="-1275" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="9">
+            <position name="cellPhysical0x1571783508_pos" unit="mm" x="-1125" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="10">
+            <position name="cellPhysical0x1571783509_pos" unit="mm" x="-1125" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="11">
+            <position name="cellPhysical0x15717835010_pos" unit="mm" x="-1125" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="12">
+            <position name="cellPhysical0x15717835011_pos" unit="mm" x="-1125" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="13">
+            <position name="cellPhysical0x15717835012_pos" unit="mm" x="-975" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="14">
+            <position name="cellPhysical0x15717835013_pos" unit="mm" x="-975" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="15">
+            <position name="cellPhysical0x15717835014_pos" unit="mm" x="-975" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="16">
+            <position name="cellPhysical0x15717835015_pos" unit="mm" x="-975" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="17">
+            <position name="cellPhysical0x15717835016_pos" unit="mm" x="-825" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="18">
+            <position name="cellPhysical0x15717835017_pos" unit="mm" x="-825" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="19">
+            <position name="cellPhysical0x15717835018_pos" unit="mm" x="-825" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="20">
+            <position name="cellPhysical0x15717835019_pos" unit="mm" x="-825" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="21">
+            <position name="cellPhysical0x15717835020_pos" unit="mm" x="-675" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="22">
+            <position name="cellPhysical0x15717835021_pos" unit="mm" x="-675" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="23">
+            <position name="cellPhysical0x15717835022_pos" unit="mm" x="-675" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="24">
+            <position name="cellPhysical0x15717835023_pos" unit="mm" x="-675" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="25">
+            <position name="cellPhysical0x15717835024_pos" unit="mm" x="-525" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="26">
+            <position name="cellPhysical0x15717835025_pos" unit="mm" x="-525" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="27">
+            <position name="cellPhysical0x15717835026_pos" unit="mm" x="-525" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="28">
+            <position name="cellPhysical0x15717835027_pos" unit="mm" x="-525" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="29">
+            <position name="cellPhysical0x15717835028_pos" unit="mm" x="-375" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="30">
+            <position name="cellPhysical0x15717835029_pos" unit="mm" x="-375" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="31">
+            <position name="cellPhysical0x15717835030_pos" unit="mm" x="-375" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="32">
+            <position name="cellPhysical0x15717835031_pos" unit="mm" x="-375" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="33">
+            <position name="cellPhysical0x15717835032_pos" unit="mm" x="-225" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="34">
+            <position name="cellPhysical0x15717835033_pos" unit="mm" x="-225" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="35">
+            <position name="cellPhysical0x15717835034_pos" unit="mm" x="-225" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="36">
+            <position name="cellPhysical0x15717835035_pos" unit="mm" x="-225" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="37">
+            <position name="cellPhysical0x15717835036_pos" unit="mm" x="-75" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="38">
+            <position name="cellPhysical0x15717835037_pos" unit="mm" x="-75" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="39">
+            <position name="cellPhysical0x15717835038_pos" unit="mm" x="-75" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="40">
+            <position name="cellPhysical0x15717835039_pos" unit="mm" x="-75" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="41">
+            <position name="cellPhysical0x15717835040_pos" unit="mm" x="75" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="42">
+            <position name="cellPhysical0x15717835041_pos" unit="mm" x="75" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="43">
+            <position name="cellPhysical0x15717835042_pos" unit="mm" x="75" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="44">
+            <position name="cellPhysical0x15717835043_pos" unit="mm" x="75" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="45">
+            <position name="cellPhysical0x15717835044_pos" unit="mm" x="225" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="46">
+            <position name="cellPhysical0x15717835045_pos" unit="mm" x="225" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="47">
+            <position name="cellPhysical0x15717835046_pos" unit="mm" x="225" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="48">
+            <position name="cellPhysical0x15717835047_pos" unit="mm" x="225" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="49">
+            <position name="cellPhysical0x15717835048_pos" unit="mm" x="375" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="50">
+            <position name="cellPhysical0x15717835049_pos" unit="mm" x="375" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="51">
+            <position name="cellPhysical0x15717835050_pos" unit="mm" x="375" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="52">
+            <position name="cellPhysical0x15717835051_pos" unit="mm" x="375" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="53">
+            <position name="cellPhysical0x15717835052_pos" unit="mm" x="525" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="54">
+            <position name="cellPhysical0x15717835053_pos" unit="mm" x="525" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="55">
+            <position name="cellPhysical0x15717835054_pos" unit="mm" x="525" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="56">
+            <position name="cellPhysical0x15717835055_pos" unit="mm" x="525" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="57">
+            <position name="cellPhysical0x15717835056_pos" unit="mm" x="675" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="58">
+            <position name="cellPhysical0x15717835057_pos" unit="mm" x="675" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="59">
+            <position name="cellPhysical0x15717835058_pos" unit="mm" x="675" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="60">
+            <position name="cellPhysical0x15717835059_pos" unit="mm" x="675" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="61">
+            <position name="cellPhysical0x15717835060_pos" unit="mm" x="825" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="62">
+            <position name="cellPhysical0x15717835061_pos" unit="mm" x="825" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="63">
+            <position name="cellPhysical0x15717835062_pos" unit="mm" x="825" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="64">
+            <position name="cellPhysical0x15717835063_pos" unit="mm" x="825" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="65">
+            <position name="cellPhysical0x15717835064_pos" unit="mm" x="975" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="66">
+            <position name="cellPhysical0x15717835065_pos" unit="mm" x="975" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="67">
+            <position name="cellPhysical0x15717835066_pos" unit="mm" x="975" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="68">
+            <position name="cellPhysical0x15717835067_pos" unit="mm" x="975" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="69">
+            <position name="cellPhysical0x15717835068_pos" unit="mm" x="1125" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="70">
+            <position name="cellPhysical0x15717835069_pos" unit="mm" x="1125" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="71">
+            <position name="cellPhysical0x15717835070_pos" unit="mm" x="1125" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="72">
+            <position name="cellPhysical0x15717835071_pos" unit="mm" x="1125" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="73">
+            <position name="cellPhysical0x15717835072_pos" unit="mm" x="1275" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="74">
+            <position name="cellPhysical0x15717835073_pos" unit="mm" x="1275" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="75">
+            <position name="cellPhysical0x15717835074_pos" unit="mm" x="1275" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="76">
+            <position name="cellPhysical0x15717835075_pos" unit="mm" x="1275" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="77">
+            <position name="cellPhysical0x15717835076_pos" unit="mm" x="1425" y="-225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="78">
+            <position name="cellPhysical0x15717835077_pos" unit="mm" x="1425" y="-75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="79">
+            <position name="cellPhysical0x15717835078_pos" unit="mm" x="1425" y="75" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+          <parameters number="80">
+            <position name="cellPhysical0x15717835079_pos" unit="mm" x="1425" y="225" z="0"/>
+            <box_dimensions lunit="mm" x="150" y="150" z="300"/>
+          </parameters>
+        </parameterised_position_size>
+      </paramvol>
+    </volume>
+    <volume name="HadCalScintiLogical0x1571790c0">
+      <materialref ref="G4_PLASTIC_SC_VINYLTOLUENE0x157171a90"/>
+      <solidref ref="HadCalScintiBox0x157178fe0"/>
+    </volume>
+    <volume name="HadCalLayerLogical0x157178dd0">
+      <materialref ref="G4_Pb0x157173590"/>
+      <solidref ref="HadCalLayerBox0x157178cf0"/>
+      <physvol name="HadCalScintiPhysical0x1571791f0">
+        <volumeref ref="HadCalScintiLogical0x1571790c0"/>
+        <position name="HadCalScintiPhysical0x1571791f0_pos" unit="mm" x="0" y="0" z="20"/>
+      </physvol>
+    </volume>
+    <volume name="HadCalCellLogical0x157178ae0">
+      <materialref ref="G4_Pb0x157173590"/>
+      <solidref ref="HadCalCellBox0x157178a00"/>
+      <replicavol number="20">
+        <volumeref ref="HadCalLayerLogical0x157178dd0"/>
+        <replicate_along_axis>
+          <direction z="1"/>
+          <width unit="mm" value="50"/>
+          <offset unit="mm" value="0"/>
+        </replicate_along_axis>
+      </replicavol>
+    </volume>
+    <volume name="HadCalColumnLogical0x1571787f0">
+      <materialref ref="G4_Pb0x157173590"/>
+      <solidref ref="HadCalColumnBox0x157178770"/>
+      <replicavol number="2">
+        <volumeref ref="HadCalCellLogical0x157178ae0"/>
+        <replicate_along_axis>
+          <direction y="1"/>
+          <width unit="mm" value="300"/>
+          <offset unit="mm" value="0"/>
+        </replicate_along_axis>
+      </replicavol>
+    </volume>
+    <volume name="HadCalorimeterLogical0x157178520">
+      <materialref ref="G4_Pb0x157173590"/>
+      <solidref ref="HadCalorimeterBox0x157178440"/>
+      <replicavol number="10">
+        <volumeref ref="HadCalColumnLogical0x1571787f0"/>
+        <replicate_along_axis>
+          <direction x="1"/>
+          <width unit="mm" value="300"/>
+          <offset unit="mm" value="0"/>
+        </replicate_along_axis>
+      </replicavol>
+    </volume>
+    <volume name="secondArmLogical0x157175390">
+      <materialref ref="G4_AIR0x15716fd60"/>
+      <solidref ref="secondArmBox0x157175310"/>
+      <physvol name="hodoscope2Physical0x1571769a0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x1571769a0_pos" unit="mm" x="-1200" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="1" name="hodoscope2Physical0x157176a70">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176a70_pos" unit="mm" x="-1100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="2" name="hodoscope2Physical0x157176af0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176af0_pos" unit="mm" x="-1000" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="3" name="hodoscope2Physical0x157176ba0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176ba0_pos" unit="mm" x="-900" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="4" name="hodoscope2Physical0x157176c10">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176c10_pos" unit="mm" x="-800" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="5" name="hodoscope2Physical0x157176d00">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176d00_pos" unit="mm" x="-700" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="6" name="hodoscope2Physical0x157176d50">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176d50_pos" unit="mm" x="-600" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="7" name="hodoscope2Physical0x157176da0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176da0_pos" unit="mm" x="-500" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="8" name="hodoscope2Physical0x157176e10">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176e10_pos" unit="mm" x="-400" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="9" name="hodoscope2Physical0x157176f80">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176f80_pos" unit="mm" x="-300" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="10" name="hodoscope2Physical0x157176ca0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176ca0_pos" unit="mm" x="-200" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="11" name="hodoscope2Physical0x157176ff0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176ff0_pos" unit="mm" x="-100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="12" name="hodoscope2Physical0x157177060">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+      </physvol>
+      <physvol copynumber="13" name="hodoscope2Physical0x1571770d0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x1571770d0_pos" unit="mm" x="100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="14" name="hodoscope2Physical0x157177140">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157177140_pos" unit="mm" x="200" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="15" name="hodoscope2Physical0x1571771b0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x1571771b0_pos" unit="mm" x="300" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="16" name="hodoscope2Physical0x157177220">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157177220_pos" unit="mm" x="400" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="17" name="hodoscope2Physical0x157176e80">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176e80_pos" unit="mm" x="500" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="18" name="hodoscope2Physical0x157176ef0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157176ef0_pos" unit="mm" x="600" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="19" name="hodoscope2Physical0x157177490">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157177490_pos" unit="mm" x="700" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="20" name="hodoscope2Physical0x1571774e0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x1571774e0_pos" unit="mm" x="800" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="21" name="hodoscope2Physical0x157177550">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157177550_pos" unit="mm" x="900" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="22" name="hodoscope2Physical0x1571775c0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x1571775c0_pos" unit="mm" x="1000" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="23" name="hodoscope2Physical0x157177630">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x157177630_pos" unit="mm" x="1100" y="0" z="0"/>
+      </physvol>
+      <physvol copynumber="24" name="hodoscope2Physical0x1571776a0">
+        <volumeref ref="hodoscope2Logical0x157176870"/>
+        <position name="hodoscope2Physical0x1571776a0_pos" unit="mm" x="1200" y="0" z="0"/>
+      </physvol>
+      <physvol name="chamber2Physical0x1571778f0">
+        <volumeref ref="chamber2Logical0x1571777d0"/>
+        <position name="chamber2Physical0x1571778f0_pos" unit="mm" x="0" y="0" z="-2500"/>
+      </physvol>
+      <physvol copynumber="1" name="chamber2Physical0x1571779b0">
+        <volumeref ref="chamber2Logical0x1571777d0"/>
+        <position name="chamber2Physical0x1571779b0_pos" unit="mm" x="0" y="0" z="-2000"/>
+      </physvol>
+      <physvol copynumber="2" name="chamber2Physical0x157177a20">
+        <volumeref ref="chamber2Logical0x1571777d0"/>
+        <position name="chamber2Physical0x157177a20_pos" unit="mm" x="0" y="0" z="-1500"/>
+      </physvol>
+      <physvol copynumber="3" name="chamber2Physical0x157177ab0">
+        <volumeref ref="chamber2Logical0x1571777d0"/>
+        <position name="chamber2Physical0x157177ab0_pos" unit="mm" x="0" y="0" z="-1000"/>
+      </physvol>
+      <physvol copynumber="4" name="chamber2Physical0x157177b20">
+        <volumeref ref="chamber2Logical0x1571777d0"/>
+        <position name="chamber2Physical0x157177b20_pos" unit="mm" x="0" y="0" z="-500"/>
+      </physvol>
+      <physvol name="EMcalorimeterPhysical0x157178080">
+        <volumeref ref="EMcalorimeterLogical0x157177f50"/>
+        <position name="EMcalorimeterPhysical0x157178080_pos" unit="mm" x="0" y="0" z="2000"/>
+      </physvol>
+      <physvol name="HadCalorimeterPhysical0x157178650">
+        <volumeref ref="HadCalorimeterLogical0x157178520"/>
+        <position name="HadCalorimeterPhysical0x157178650_pos" unit="mm" x="0" y="0" z="3000"/>
+      </physvol>
+    </volume>
+    <volume name="worldLogical0x1571743d0">
+      <materialref ref="G4_AIR0x15716fd60"/>
+      <solidref ref="worldBox0x157173ff0"/>
+      <physvol name="magneticPhysical0x157174ea0">
+        <volumeref ref="magneticLogical0x157174d60"/>
+        <rotation name="magneticPhysical0x157174ea0_rot" unit="deg" x="90" y="0" z="0"/>
+      </physvol>
+      <physvol name="firstArmPhysical0x1571751f0">
+        <volumeref ref="firstArmLogical0x1571750c0"/>
+        <position name="firstArmPhysical0x1571751f0_pos" unit="mm" x="0" y="0" z="-5000"/>
+      </physvol>
+      <physvol name="fSecondArmPhys0x1571754c0">
+        <volumeref ref="secondArmLogical0x157175390"/>
+        <position name="fSecondArmPhys0x1571754c0_pos" unit="mm" x="-2500" y="0" z="4330.12701892219"/>
+        <rotation name="fSecondArmPhys0x1571754c0_rot" unit="deg" x="0" y="30" z="0"/>
+      </physvol>
+    </volume>
+  </structure>
+
+  <setup name="Default" version="1.0">
+    <world ref="worldLogical0x1571743d0"/>
+  </setup>
+
+</gdml>


### PR DESCRIPTION
The need to support conversion of `G4PVReplica` into an equivalent VecGeom form has been identified in AdePT/Celeritas benchmarks using Geant4's example B5. This uses `G4PVReplica` to model some of its geometry components, and use of  G4VG to convert this conversion fail as there is no direct equivalent in VecGeom.

Like `G4PVParameterised`, a VecGeom equivalent can be implemented at the cost of some efficiency by creating individual placements of the replicas. The changes here implement this to do the conversion, largely following what is done for parametrised volumes. The main differences are:

- Use `G4ReplicaNavigation` to transform the replicated volume before placing it in VecGeom (`G4PVReplica` does not provide a `G4VPVParameterisation` instance to do this`).
- Copy number is set, as this is likely needed for scoring (to be confirmed).

As implemented, this is really only going to support rotational or linear replication. Radial replication appears to imply a changes to the underlying solid's dimensions which would be more complex. I haven't implemented an error on this case yet as I wanted to check things are on the right general track first.

A basic unit test is also provided using a GDML generated from the default output of the B5 example. This passes as of the tip commit, but:

- I had to modify the raw GDML file (281a71) to remove the pointers from the top volume name (9f40450) otherwise the test would fail:

  ```
  7: -------- EEEE ------- G4Exception-START -------- EEEE -------
  7: 
  7: *** ExceptionHandler is not defined ***
  7: *** G4Exception : ReadError
  7:       issued by : G4GDMLReadStructure::GetVolume()
  7: Referenced volume 'worldLogical0x1571743d0' was not found!
  7: *** Fatal Exception ***
  7: -------- EEEE ------- G4Exception-END -------- EEEE -------
  ```

  Not sure if that's something I did wrong in creating the exported GDML, or something on the G4VG side.

- The setup of the `pv_name` vector is a bit messy given the number of repeated volume names and how these are interleaved with non-repeated names.